### PR TITLE
Fix chrome.storage undefined error in expression bad practice warning

### DIFF
--- a/features/expression-bad-practice-warning/expression-bad-practice-warning.js
+++ b/features/expression-bad-practice-warning/expression-bad-practice-warning.js
@@ -13,14 +13,19 @@ let warningPrefs = {
 };
 
 // Load user preferences for specific warning types
-chrome.storage.sync.get([
-  'expression_bad_practice_warning_count_is_zero',
-  'expression_bad_practice_warning_current_user_in_backend'
-], (result) => {
-  warningPrefs.countIsZero = result.expression_bad_practice_warning_count_is_zero !== false; // Default to true if not set
-  warningPrefs.currentUserInBackend = result.expression_bad_practice_warning_current_user_in_backend !== false; // Default to true if not set
-  console.log("❤️"+"Warning preferences loaded:", warningPrefs);
-});
+if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync) {
+  chrome.storage.sync.get([
+    'expression_bad_practice_warning_count_is_zero',
+    'expression_bad_practice_warning_current_user_in_backend'
+  ], (result) => {
+    warningPrefs.countIsZero = result.expression_bad_practice_warning_count_is_zero !== false; // Default to true if not set
+    warningPrefs.currentUserInBackend = result.expression_bad_practice_warning_current_user_in_backend !== false; // Default to true if not set
+    console.log("❤️"+"Warning preferences loaded:", warningPrefs);
+  });
+} else {
+  // Use default values when chrome.storage is not available
+  console.log("❤️"+"Chrome storage not available, using default warning preferences:", warningPrefs);
+}
 
 let debounceTimeout;
 let isProcessing = false; // Flag to prevent redundant processing


### PR DESCRIPTION
## Summary
- Fixed runtime error when chrome.storage API is not available
- Added proper checks before accessing chrome.storage.sync
- Script now gracefully falls back to default warning preferences

## Problem
The expression bad practice warning script was throwing an error:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'sync')
```

This occurred because the script is injected into the page context where Chrome extension APIs like `chrome.storage` are not available.

## Solution
Added conditional checks to verify that:
1. The `chrome` object exists
2. `chrome.storage` exists
3. `chrome.storage.sync` exists

When these APIs are not available, the script uses the default warning preferences and logs a message to the console.

## Test plan
- [x] Verify the script no longer throws errors when loaded
- [x] Confirm bad practice warnings still appear with default settings
- [x] Test that user preferences are loaded when chrome.storage is available